### PR TITLE
[journey] Fix remaining path segment growing the wrong way

### DIFF
--- a/src/components/Journey.vue
+++ b/src/components/Journey.vue
@@ -141,7 +141,7 @@ let showingAbortJourneyPrompt = $ref(false)
 							background-image: repeating-linear-gradient(transparent, transparent 6px, $clr-disabled-text-light 6px, $clr-disabled-text-light 12px)
 						&.partial
 							flex: none
-							height: calc(var(--remaining) * (100% - 26px))
+							height: calc((1 - var(--remaining)) * (100% - 26px))
 				&:not(.reached)
 					margin-bottom: 128px
 					.waypoint


### PR DESCRIPTION
Fixes the "remaining" bar of the current path segment was inverted: it started at full height (i.e. touch the next segment) and then shrink towards completion.